### PR TITLE
Simplified test for adapter slices dependency on each other

### DIFF
--- a/src/test/kotlin/com/github/spanierm/archunitjunit5kotlin/onion/OnionArchitectureTest.kt
+++ b/src/test/kotlin/com/github/spanierm/archunitjunit5kotlin/onion/OnionArchitectureTest.kt
@@ -47,7 +47,7 @@ internal class OnionArchitectureTest {
     @ArchTest
     val `one adapter should not access another adapter` =
         slices()
-                .matching("$ADAPTER_PACKAGE.(**)")
+                .matching("$ADAPTER_PACKAGE.(*)")
                 .should().notDependOnEachOther()
 
     companion object {


### PR DESCRIPTION
In ArchUnit there is now this method SlicesRuleDefinition#slices which hugely simplifies stuff (e.g. the choice of testing framework for ArchUnit)